### PR TITLE
Fix temp permissions automatically

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,16 @@ COPY . .
 # 7. Create Non-root User
 RUN groupadd -r appuser && useradd --no-log-init -r -g appuser appuser && \
     chown -R appuser:appuser /app
-USER appuser
+
+# Copy entrypoint script and make it executable
+COPY entrypoint.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
+
+# Run as root so the entrypoint can fix permissions before dropping privileges
+USER root
+
+# Use the entrypoint to adjust permissions then launch the app as appuser
+ENTRYPOINT ["/app/entrypoint.sh"]
 
 # 8. Expose Port
 EXPOSE 5018

--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ The application provides a clean web interface with separate tabs for each step,
     docker run -p 5018:5018 -v "$(pwd)/temp:/app/temp" --rm --name paint2black-app paint2black-ocr
     ```
     *(Note: On Windows PowerShell, use `${pwd}` instead of `$(pwd)` for the volume path)*
+
+    The container's startup script automatically sets correct permissions on
+    `/app/temp`, so the application can write uploaded files without any manual
+    permission changes on the host.
 6.  **Access the Application:** Open your web browser and navigate to `http://localhost:5018`.
 
 ## Usage

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+# Ensure the temporary directory exists and has correct ownership
+mkdir -p /app/temp
+chown -R appuser:appuser /app/temp
+
+# Execute the given command as appuser
+exec /usr/sbin/runuser -u appuser -- "$@"


### PR DESCRIPTION
## Summary
- ensure `/app/temp` ownership on container startup
- run container as root initially and drop privileges via new entrypoint script
- document that permissions are handled automatically

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_686d269a31b4832ebdee3ce453ab4de4